### PR TITLE
View Stale Products

### DIFF
--- a/app/controllers/pressEnterToContinue.js
+++ b/app/controllers/pressEnterToContinue.js
@@ -5,6 +5,7 @@ const prompt = require('prompt');
  * @function
  * @description Call when you want to wait for any input before moving on.
  * @name pressEnterToContinue
+ * @param {string} [message = 'Press any key to continue'] Message to be displayed before asking user to press any key.
  * @returns A promise
  */
 module.exports = (message = `Press any key to continue`) => {

--- a/app/controllers/pressEnterToContinue.js
+++ b/app/controllers/pressEnterToContinue.js
@@ -6,7 +6,7 @@ const prompt = require('prompt');
  * @description Call when you want to wait for any input before moving on.
  * @name pressEnterToContinue
  * @param {string} [message = 'Press any key to continue'] Message to be displayed before asking user to press any key.
- * @returns A promise
+ * @returns {promise}
  */
 module.exports = (message = `Press any key to continue`) => {
     console.log(message);

--- a/app/controllers/pressEnterToContinue.js
+++ b/app/controllers/pressEnterToContinue.js
@@ -7,8 +7,8 @@ const prompt = require('prompt');
  * @name pressEnterToContinue
  * @returns A promise
  */
-module.exports = () => {
-    console.log(`Press any key to continue`);
+module.exports = (message = `Press any key to continue`) => {
+    console.log(message);
     return new Promise((resolve, reject) => {
         prompt.get([
             {

--- a/app/controllers/pressEnterToContinue.js
+++ b/app/controllers/pressEnterToContinue.js
@@ -8,7 +8,7 @@ const prompt = require('prompt');
  * @param {string} [message = 'Press any key to continue'] Message to be displayed before asking user to press any key.
  * @returns {promise}
  */
-module.exports = (message = `Press any key to continue`) => {
+module.exports = (message = ` Press any key to continue`) => {
     console.log(message);
     return new Promise((resolve, reject) => {
         prompt.get([

--- a/app/controllers/pressEnterToContinue.js
+++ b/app/controllers/pressEnterToContinue.js
@@ -1,0 +1,24 @@
+'use strict';
+const prompt = require('prompt');
+
+/**
+ * @function
+ * @description Call when you want to wait for any input before moving on.
+ * @name pressEnterToContinue
+ * @returns A promise
+ */
+module.exports = () => {
+    console.log(`Press any key to continue`);
+    return new Promise((resolve, reject) => {
+        prompt.get([
+            {
+                name: ' ',
+                description: ``,
+                message: ``
+            },
+        ],
+            (err, results) => {
+                return err ? reject(err) : resolve(err);
+            })
+    });
+}

--- a/app/models/GetStaleProducts.js
+++ b/app/models/GetStaleProducts.js
@@ -1,0 +1,41 @@
+'use strict';
+const { Database } = require('sqlite3').verbose();
+const { setActiveCustomer, getActiveCustomer } = require('../activeCustomer');
+const path = require('path');
+const db = new Database(path.join(__dirname, '..', '..', 'bangazon.sqlite'));
+
+
+/**
+ * @function
+ * @name getStaleProducts
+ * @param {integer} customerId
+ * @description Returns a list of stale products for a given customer
+ * @returns {Array.<{product}>} An array of products.
+ */
+module.exports = customerId => {
+    return new Promise((resolve, reject) => {
+
+        // A stale product meeets any of the following criteria:
+
+        // Is stale option 1:  Has never been added to an order, and has been in the system for more than 180 days
+        const neverAddedSql = ``;
+
+
+        return db.all(
+            `SELECT customer_id AS id, (first_name || ' ' || last_name) AS name]
+            FROM customers`,
+            (err, products) => {
+                return err ? reject(err) : resolve(products);
+            });
+    });
+};
+
+
+
+// Is stale option 2:  Has been added to an order, 
+// but the order hasn't been completed, 
+// and the order was created more than 90 days ago
+
+// Is stale option 3:  Has been added to one, 
+// or more orders, and the order were completed, 
+// but there is remaining quantity for the product, and the product has been in the system for more than 180 days

--- a/app/models/GetStaleProducts.js
+++ b/app/models/GetStaleProducts.js
@@ -14,52 +14,8 @@ const db = new Database(path.join(__dirname, '..', '..', 'bangazon.sqlite'));
  */
 module.exports = customerId => {
     return new Promise((resolve, reject) => {
-
-        // A stale product meeets any of the following criteria:
-
-        // Is stale option 1:  Has never been added to an order, and has been in the system for more than 180 days
-        const neverAddedSql = `SELECT P.product_id, P.product_name
-        FROM products AS P
-        WHERE 
-            P.product_id NOT IN (
-                SELECT OP.product_id
-                FROM order_products AS OP
-            )
-            AND 
-            CAST(JULIANDAY('now') - JULIANDAY(REPLACE(P.listing_date, '/', '-')) as INT) >= 180;`;
-
-        // Is stale option 2:  Has been added to an order, 
-        // but the order hasn't been completed(If payment_type is null, it has not been completed.),
-        // and the order was created more than 90 days ago
-        const addedToNotCompletedOrderSql = `
-        SELECT P.product_id, P.product_name
-        FROM order_products AS OP 
-        INNER JOIN products AS P
-            ON P.product_id = OP.product_id
-        INNER JOIN orders AS O 
-            ON O.order_id = OP.order_id
-        WHERE CAST(JULIANDAY('now') - JULIANDAY(O.order_date) as INT) >= 90
-            AND O.payment_type IS NULL;`;
-
-        // Is stale option 3:  Has been added to one, 
-        // or more orders, and the order were completed, 
-        // but there is remaining quantity for the product, 
-        // and the product has been in the system for more than 180 days
-        const addedToCompleteOrderButRemainingQuantitySQL = `
-        SELECT P.product_id, P.product_name
-        FROM order_products AS OP 
-        INNER JOIN products AS P
-            ON P.product_id = OP.product_id
-        INNER JOIN orders AS O 
-            ON O.order_id = OP.order_id
-        WHERE CAST(JULIANDAY('now') - JULIANDAY(O.order_date) as INT) >= 180
-            AND O.payment_type IS NOT NULL 
-            AND P.quantity > 0;`;
-
-
         return db.all(
-            `SELECT customer_id AS id, (first_name || ' ' || last_name) AS name]
-            FROM customers`,
+            selectStaleProductSql,
             (err, products) => {
                 return err ? reject(err) : resolve(products);
             });

--- a/app/models/GetStaleProducts.js
+++ b/app/models/GetStaleProducts.js
@@ -17,7 +17,7 @@ const getStaleProductsSql = require('./sql/selectStaleProductsSql');
 module.exports = customerId => {
     return new Promise((resolve, reject) => {
         return db.all(
-            getStaleProductsSql,
+            getStaleProductsSql(customerId),
             (err, products) => {
                 return err ? reject(err) : resolve(products);
             });

--- a/app/models/GetStaleProducts.js
+++ b/app/models/GetStaleProducts.js
@@ -29,9 +29,15 @@ module.exports = customerId => {
             CAST(JULIANDAY('now') - JULIANDAY(REPLACE(P.listing_date, '/', '-')) as INT) >= 180;`;
 
         // Is stale option 2:  Has been added to an order, 
-        // but the order hasn't been completed, 
+        // but the order hasn't been completed(If payment_type is null, it has not been completed.),
         // and the order was created more than 90 days ago
-        const addedToNotCompletedOrderSql = ``;
+        const addedToNotCompletedOrderSql = `SELECT P.product_id, P.product_name
+        FROM order_products AS OP 
+        INNER JOIN products AS P
+            ON P.product_id = OP.product_id
+        INNER JOIN orders AS O 
+            ON O.order_id = OP.order_id
+        WHERE CAST(JULIANDAY('now') - JULIANDAY(O.order_date) as INT) >= 90;`;
 
         return db.all(
             `SELECT customer_id AS id, (first_name || ' ' || last_name) AS name]

--- a/app/models/GetStaleProducts.js
+++ b/app/models/GetStaleProducts.js
@@ -31,13 +31,22 @@ module.exports = customerId => {
         // Is stale option 2:  Has been added to an order, 
         // but the order hasn't been completed(If payment_type is null, it has not been completed.),
         // and the order was created more than 90 days ago
-        const addedToNotCompletedOrderSql = `SELECT P.product_id, P.product_name
+        const addedToNotCompletedOrderSql = `
+        SELECT P.product_id, P.product_name
         FROM order_products AS OP 
         INNER JOIN products AS P
             ON P.product_id = OP.product_id
         INNER JOIN orders AS O 
             ON O.order_id = OP.order_id
-        WHERE CAST(JULIANDAY('now') - JULIANDAY(O.order_date) as INT) >= 90;`;
+        WHERE CAST(JULIANDAY('now') - JULIANDAY(O.order_date) as INT) >= 90
+            AND O.payment_type IS NULL;`;
+
+        // Is stale option 3:  Has been added to one, 
+        // or more orders, and the order were completed, 
+        // but there is remaining quantity for the product, 
+        // and the product has been in the system for more than 180 days
+        const addedToCompleteOrderButRemainingQuantitySQL = ``;
+
 
         return db.all(
             `SELECT customer_id AS id, (first_name || ' ' || last_name) AS name]
@@ -51,6 +60,3 @@ module.exports = customerId => {
 
 
 
-// Is stale option 3:  Has been added to one, 
-// or more orders, and the order were completed, 
-// but there is remaining quantity for the product, and the product has been in the system for more than 180 days

--- a/app/models/GetStaleProducts.js
+++ b/app/models/GetStaleProducts.js
@@ -45,7 +45,16 @@ module.exports = customerId => {
         // or more orders, and the order were completed, 
         // but there is remaining quantity for the product, 
         // and the product has been in the system for more than 180 days
-        const addedToCompleteOrderButRemainingQuantitySQL = ``;
+        const addedToCompleteOrderButRemainingQuantitySQL = `
+        SELECT P.product_id, P.product_name
+        FROM order_products AS OP 
+        INNER JOIN products AS P
+            ON P.product_id = OP.product_id
+        INNER JOIN orders AS O 
+            ON O.order_id = OP.order_id
+        WHERE CAST(JULIANDAY('now') - JULIANDAY(O.order_date) as INT) >= 180
+            AND O.payment_type IS NOT NULL 
+            AND P.quantity > 0;`;
 
 
         return db.all(

--- a/app/models/GetStaleProducts.js
+++ b/app/models/GetStaleProducts.js
@@ -18,8 +18,20 @@ module.exports = customerId => {
         // A stale product meeets any of the following criteria:
 
         // Is stale option 1:  Has never been added to an order, and has been in the system for more than 180 days
-        const neverAddedSql = ``;
+        const neverAddedSql = `SELECT P.product_id, P.product_name
+        FROM products AS P
+        WHERE 
+            P.product_id NOT IN (
+                SELECT OP.product_id
+                FROM order_products AS OP
+            )
+            AND 
+            CAST(JULIANDAY('now') - JULIANDAY(REPLACE(P.listing_date, '/', '-')) as INT) >= 180;`;
 
+        // Is stale option 2:  Has been added to an order, 
+        // but the order hasn't been completed, 
+        // and the order was created more than 90 days ago
+        const addedToNotCompletedOrderSql = ``;
 
         return db.all(
             `SELECT customer_id AS id, (first_name || ' ' || last_name) AS name]
@@ -32,9 +44,6 @@ module.exports = customerId => {
 
 
 
-// Is stale option 2:  Has been added to an order, 
-// but the order hasn't been completed, 
-// and the order was created more than 90 days ago
 
 // Is stale option 3:  Has been added to one, 
 // or more orders, and the order were completed, 

--- a/app/models/GetStaleProducts.js
+++ b/app/models/GetStaleProducts.js
@@ -4,6 +4,8 @@ const { setActiveCustomer, getActiveCustomer } = require('../activeCustomer');
 const path = require('path');
 const db = new Database(path.join(__dirname, '..', '..', 'bangazon.sqlite'));
 
+const getStaleProductsSql = require('./sql/selectStaleProductsSql');
+
 
 /**
  * @function
@@ -15,7 +17,7 @@ const db = new Database(path.join(__dirname, '..', '..', 'bangazon.sqlite'));
 module.exports = customerId => {
     return new Promise((resolve, reject) => {
         return db.all(
-            selectStaleProductSql,
+            getStaleProductsSql,
             (err, products) => {
                 return err ? reject(err) : resolve(products);
             });

--- a/app/models/sql/selectStaleProductSql.js
+++ b/app/models/sql/selectStaleProductSql.js
@@ -1,0 +1,52 @@
+'use strict';
+
+// A stale product meeets any of the following criteria:
+// Is stale option 1:  Has never been added to an order, and has been in the system for more than 180 days
+
+// Is stale option 2:  Has been added to an order, 
+// but the order hasn't been completed(If payment_type is null, it has not been completed.),
+// and the order was created more than 90 days ago
+
+// Is stale option 3:  Has been added to one, 
+// or more orders, and the order were completed, 
+// but there is remaining quantity for the product, 
+// and the product has been in the system for more than 180 days
+
+/**
+ * @property
+ * @name selectStaleProductSql
+ * @description An abstraction of huge sql statments used to select stale products.
+ */
+module.exports = `
+    -- Option 1
+    SELECT P.product_id, P.product_name
+        FROM products AS P
+        WHERE 
+            P.product_id NOT IN (
+                SELECT OP.product_id
+                FROM order_products AS OP
+            )
+            AND 
+            CAST(JULIANDAY('now') - JULIANDAY(REPLACE(P.listing_date, '/', '-')) as INT) >= 180
+    UNION ALL 
+    -- Option  2
+        SELECT P.product_id, P.product_name
+        FROM order_products AS OP 
+        INNER JOIN products AS P
+            ON P.product_id = OP.product_id
+        INNER JOIN orders AS O 
+            ON O.order_id = OP.order_id
+        WHERE CAST(JULIANDAY('now') - JULIANDAY(O.order_date) as INT) >= 90
+            AND O.payment_type IS NULL
+    UNION ALL
+    -- Option 3
+    SELECT P.product_id, P.product_name
+        FROM order_products AS OP 
+        INNER JOIN products AS P
+            ON P.product_id = OP.product_id
+        INNER JOIN orders AS O 
+            ON O.order_id = OP.order_id
+        WHERE CAST(JULIANDAY('now') - JULIANDAY(O.order_date) as INT) >= 180
+            AND O.payment_type IS NOT NULL 
+            AND P.quantity > 0;
+    `;

--- a/app/models/sql/selectStaleProductsSql.js
+++ b/app/models/sql/selectStaleProductsSql.js
@@ -15,46 +15,49 @@ module.exports = customerId => {
     assert.equal(Number.isInteger(customerId), true);
 
     return `
-    -- Has never been added to an order, and has been in the system for more than 180 days
-    SELECT P.product_id, P.product_name
-        FROM products AS P
-        WHERE 
-            P.product_id NOT IN (
-                SELECT OP.product_id
-                FROM order_products AS OP
-            )
-            AND 
-            CAST(JULIANDAY('now') - JULIANDAY(REPLACE(P.listing_date, '/', '-')) as INT) >= 180
-            AND P.customer_id = ${customerId}
-    UNION ALL 
-
-    -- Has been added to an order, 
-    -- but the order hasn't been completed(If payment_type is null, it has not been completed.),
-    -- and the order was created more than 90 days ago
-        SELECT P.product_id, P.product_name
-        FROM order_products AS OP 
-        INNER JOIN products AS P
-            ON P.product_id = OP.product_id
-        INNER JOIN orders AS O 
-            ON O.order_id = OP.order_id
-        WHERE CAST(JULIANDAY('now') - JULIANDAY(O.order_date) as INT) >= 90
-            AND O.payment_type IS NULL
-            AND P.customer_id = ${customerId}  
-    UNION ALL
-
-    -- Has been added to one, 
-    -- or more orders, and the order were completed, 
-    -- but there is remaining quantity for the product, 
-    -- and the product has been in the system for more than 180 days
-    SELECT P.product_id, P.product_name
-        FROM order_products AS OP 
-        INNER JOIN products AS P
-            ON P.product_id = OP.product_id
-        INNER JOIN orders AS O 
-            ON O.order_id = OP.order_id
-        WHERE CAST(JULIANDAY('now') - JULIANDAY(O.order_date) as INT) >= 180
-            AND O.payment_type IS NOT NULL 
-            AND P.quantity > 0
-            AND P.customer_id = ${customerId};
+    SELECT distinct(product_id), product_name FROM (
+        -- Has never been added to an order, and has been in the system for more than 180 days
+            SELECT P.product_id, P.product_name
+                FROM products AS P
+                WHERE 
+                    P.product_id NOT IN (
+                        SELECT OP.product_id
+                        FROM order_products AS OP
+                    )
+                    AND 
+                    CAST(JULIANDAY('now') - JULIANDAY(REPLACE(P.listing_date, '/', '-')) as INT) >= 180
+                    AND P.customer_id = ${customerId}
+            UNION ALL 
+        
+            -- Has been added to an order, 
+            -- but the order hasn't been completed(If payment_type is null, it has not been completed.),
+            -- and the order was created more than 90 days ago
+                SELECT P.product_id, P.product_name
+                FROM order_products AS OP 
+                INNER JOIN products AS P
+                    ON P.product_id = OP.product_id
+                INNER JOIN orders AS O 
+                    ON O.order_id = OP.order_id
+                WHERE CAST(JULIANDAY('now') - JULIANDAY(O.order_date) as INT) >= 90
+                    AND O.payment_type IS NULL
+                    AND P.customer_id = ${customerId}
+            UNION ALL
+        
+            -- Has been added to one, 
+            -- or more orders, and the order were completed, 
+            -- but there is remaining quantity for the product, 
+            -- and the product has been in the system for more than 180 days
+            SELECT P.product_id, P.product_name
+                FROM order_products AS OP 
+                INNER JOIN products AS P
+                    ON P.product_id = OP.product_id
+                INNER JOIN orders AS O 
+                    ON O.order_id = OP.order_id
+                WHERE CAST(JULIANDAY('now') - JULIANDAY(O.order_date) as INT) >= 180
+                    AND O.payment_type IS NOT NULL 
+                    AND P.quantity > 0
+                    AND P.customer_id = ${customerId}
+                    );
     `;
 };
+

--- a/app/models/sql/selectStaleProductsSql.js
+++ b/app/models/sql/selectStaleProductsSql.js
@@ -1,24 +1,20 @@
 'use strict';
+const assert = require('assert');
 
-// A stale product meeets any of the following criteria:
-// Is stale option 1:  Has never been added to an order, and has been in the system for more than 180 days
-
-// Is stale option 2:  Has been added to an order, 
-// but the order hasn't been completed(If payment_type is null, it has not been completed.),
-// and the order was created more than 90 days ago
-
-// Is stale option 3:  Has been added to one, 
-// or more orders, and the order were completed, 
-// but there is remaining quantity for the product, 
-// and the product has been in the system for more than 180 days
 
 /**
- * @property
+ * @function
  * @name selectStaleProductsSql
  * @description An abstraction of huge sql statments used to select stale products.
+ * @returns Sql code with customer id inserted into the where clause.
  */
-module.exports = `
-    -- Option 1
+module.exports = customerId => {
+
+    // customer id should be integer
+    assert.equal(Number.isInteger(customerId), true);
+
+    return `
+    -- Has never been added to an order, and has been in the system for more than 180 days
     SELECT P.product_id, P.product_name
         FROM products AS P
         WHERE 
@@ -28,8 +24,12 @@ module.exports = `
             )
             AND 
             CAST(JULIANDAY('now') - JULIANDAY(REPLACE(P.listing_date, '/', '-')) as INT) >= 180
+            AND P.customer_id = ${customerId}
     UNION ALL 
-    -- Option  2
+
+    -- Has been added to an order, 
+    -- but the order hasn't been completed(If payment_type is null, it has not been completed.),
+    -- and the order was created more than 90 days ago
         SELECT P.product_id, P.product_name
         FROM order_products AS OP 
         INNER JOIN products AS P
@@ -38,8 +38,13 @@ module.exports = `
             ON O.order_id = OP.order_id
         WHERE CAST(JULIANDAY('now') - JULIANDAY(O.order_date) as INT) >= 90
             AND O.payment_type IS NULL
+            AND P.customer_id = ${customerId}  
     UNION ALL
-    -- Option 3
+
+    -- Is stale option 3:  Has been added to one, 
+    -- or more orders, and the order were completed, 
+    -- but there is remaining quantity for the product, 
+    -- and the product has been in the system for more than 180 days
     SELECT P.product_id, P.product_name
         FROM order_products AS OP 
         INNER JOIN products AS P
@@ -48,5 +53,7 @@ module.exports = `
             ON O.order_id = OP.order_id
         WHERE CAST(JULIANDAY('now') - JULIANDAY(O.order_date) as INT) >= 180
             AND O.payment_type IS NOT NULL 
-            AND P.quantity > 0;
+            AND P.quantity > 0
+            AND P.customer_id = ${customerId};
     `;
+};

--- a/app/models/sql/selectStaleProductsSql.js
+++ b/app/models/sql/selectStaleProductsSql.js
@@ -41,7 +41,7 @@ module.exports = customerId => {
             AND P.customer_id = ${customerId}  
     UNION ALL
 
-    -- Is stale option 3:  Has been added to one, 
+    -- Has been added to one, 
     -- or more orders, and the order were completed, 
     -- but there is remaining quantity for the product, 
     -- and the product has been in the system for more than 180 days

--- a/app/models/sql/selectStaleProductsSql.js
+++ b/app/models/sql/selectStaleProductsSql.js
@@ -5,6 +5,7 @@ const assert = require('assert');
 /**
  * @function
  * @name selectStaleProductsSql
+ * @param {integer} customerId - The id of the customer whos stale products you are finding.
  * @description An abstraction of a huge sql statments used to select stale products.
  * @returns Sql code with customer id inserted into the where clause.
  */

--- a/app/models/sql/selectStaleProductsSql.js
+++ b/app/models/sql/selectStaleProductsSql.js
@@ -7,7 +7,7 @@ const assert = require('assert');
  * @name selectStaleProductsSql
  * @param {integer} customerId - The id of the customer whos stale products you are finding.
  * @description An abstraction of a huge sql statments used to select stale products.
- * @returns Sql code with customer id inserted into the where clause.
+ * @returns {string} Sql code with customer id inserted into the where clause.
  */
 module.exports = customerId => {
 
@@ -16,7 +16,7 @@ module.exports = customerId => {
 
     return `
     SELECT distinct(product_id), product_name FROM (
-        
+
         -- Has never been added to an order, and has been in the system for more than 180 days
             SELECT P.product_id, P.product_name
                 FROM products AS P

--- a/app/models/sql/selectStaleProductsSql.js
+++ b/app/models/sql/selectStaleProductsSql.js
@@ -16,6 +16,7 @@ module.exports = customerId => {
 
     return `
     SELECT distinct(product_id), product_name FROM (
+        
         -- Has never been added to an order, and has been in the system for more than 180 days
             SELECT P.product_id, P.product_name
                 FROM products AS P

--- a/app/models/sql/selectStaleProductsSql.js
+++ b/app/models/sql/selectStaleProductsSql.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 /**
  * @function
  * @name selectStaleProductsSql
- * @description An abstraction of huge sql statments used to select stale products.
+ * @description An abstraction of a huge sql statments used to select stale products.
  * @returns Sql code with customer id inserted into the where clause.
  */
 module.exports = customerId => {

--- a/app/models/sql/selectStaleProductsSql.js
+++ b/app/models/sql/selectStaleProductsSql.js
@@ -14,7 +14,7 @@
 
 /**
  * @property
- * @name selectStaleProductSql
+ * @name selectStaleProductsSql
  * @description An abstraction of huge sql statments used to select stale products.
  */
 module.exports = `

--- a/app/ui.js
+++ b/app/ui.js
@@ -12,23 +12,27 @@ const db = new Database(path.join(__dirname, '..', 'bangazon.sqlite'));
 prompt.message = colors.blue("Bangazon Corp");
 
 /*
-CONTROLLERS
+  CONTROLLERS
 */
 const { promptNewCustomer } = require('./controllers/customerCtrl')
 const promptActivateCustomer = require('./controllers/activateCustomerCtrl')
 const { promptPaymentType } = require('./controllers/addPaymentTypeCtrl')
 
 /*
-MODELS
+  MODELS
 */
 const getCustomers = require('./models/getCustomers');
 const { addCustomerPaymentType } = require('./models/AddPaymentType');
 
 /*
-ACtiVE CUSTOMER
+  ACTIVE CUSTOMER
 */
 const { setActiveCustomer, getActiveCustomer, isActiveCustomerSet } = require('../app/activeCustomer');
 
+
+/*
+  START OF CLI
+*/
 prompt.start();
 
 const mainMenuHandler = (err, { choice }) => {

--- a/app/ui.js
+++ b/app/ui.js
@@ -3,6 +3,8 @@
 // 3rd party libs
 const { red, magenta, blue } = require("chalk");
 
+const assert = require('assert');
+
 const prompt = require('prompt');
 const colors = require("colors/safe");
 const path = require('path');
@@ -32,6 +34,21 @@ const getStaleProducts = require('./models/GetStaleProducts');
 */
 const { setActiveCustomer, getActiveCustomer, isActiveCustomerSet } = require('../app/activeCustomer');
 
+const addSpace = (object, properties) => {
+  assert.equal(Array.isArray(properties), true);
+
+  for(let prop of properties){
+    if(typeof object[prop] !== 'undefined'){
+      
+      // To convert value to string to allow padstart
+      object[prop] = `${object[prop]}`;
+
+      object[prop] = object[prop].padStart(object[prop].length + 2, " ");
+    }
+  }
+  
+  return object;
+};
 
 /*
   START OF CLI
@@ -58,7 +75,8 @@ const mainMenuHandler = (err, { choice }) => {
 
         // List of customer ids
         for (let customer of customers) {
-          console.log(customer.id, customer.name);
+          customer = addSpace(customer, ['id']);
+          console.log(`${customer.id}.`, customer.name);
         }
 
         promptActivateCustomer(customers.length)
@@ -88,18 +106,26 @@ const mainMenuHandler = (err, { choice }) => {
     }
 
     // View stale products
-    // 4 has stale products
     case 7: {
-      //check if active customer
       if(isActiveCustomerSet()){
         getStaleProducts(getActiveCustomer().id).then(products => {
-          console.table(products);
+          if(products.length > 0) {
+
+            // Required indent to conform with Joe's CLI code.
+            for(let product of products){
+              product = addSpace(product, ['product_id']);
+            }
+            
+            console.table(products);
+          } else {
+            console.log(' No stale products');
+          }
           pressEnterToContinue().then(() => {
             displayWelcome();
           });
         });
       } else {
-        console.log('Please choose active customer before checking their stale  products');
+        console.log(' Please choose active customer before checking their stale  products');
         displayWelcome();
       }
       break;

--- a/app/ui.js
+++ b/app/ui.js
@@ -21,7 +21,7 @@ const { promptPaymentType } = require('./controllers/addPaymentTypeCtrl')
 /*
   MODELS
 */
-const getCustomers = require('./models/getCustomers');
+const getCustomers = require('./models/GetCustomers');
 const { addCustomerPaymentType } = require('./models/AddPaymentType');
 
 /*

--- a/app/ui.js
+++ b/app/ui.js
@@ -26,12 +26,8 @@ const pressEnterToContinue = require('./controllers/pressEnterToContinue')
 /*
   MODELS
 */
-<<<<<<< HEAD
 const getCustomers = require('./models/GetCustomers');
-=======
-const getCustomers = require('./models/getCustomers');
 const addCustomerProduct = require('./models/AddCustomerProduct');
->>>>>>> 1bfd0ed8fe173abc829652b740807bf33e543e3d
 const { addCustomerPaymentType } = require('./models/AddPaymentType');
 const getStaleProducts = require('./models/GetStaleProducts');
 
@@ -43,16 +39,16 @@ const { setActiveCustomer, getActiveCustomer, isActiveCustomerSet } = require('.
 const addSpace = (object, properties) => {
   assert.equal(Array.isArray(properties), true);
 
-  for(let prop of properties){
-    if(typeof object[prop] !== 'undefined'){
-      
+  for (let prop of properties) {
+    if (typeof object[prop] !== 'undefined') {
+
       // To convert value to string to allow padstart
       object[prop] = `${object[prop]}`;
 
       object[prop] = object[prop].padStart(object[prop].length + 2, " ");
     }
   }
-  
+
   return object;
 };
 
@@ -87,8 +83,8 @@ const mainMenuHandler = (err, { choice }) => {
 
         promptActivateCustomer(customers.length)
           .then(({ customerId }) => {
-            const customer = customers.find(({id}) => +id === +customerId);
-            
+            const customer = customers.find(({ id }) => +id === +customerId);
+
             setActiveCustomer(+customer.id, customer.name);
             displayWelcome();
           });
@@ -99,9 +95,9 @@ const mainMenuHandler = (err, { choice }) => {
     // Add Payment Type
     case 3: {
       //check if active customer
-      if(getActiveCustomer().id){
+      if (getActiveCustomer().id) {
         promptPaymentType().then((paymentData) => {
-          addCustomerPaymentType(getActiveCustomer(),paymentData);
+          addCustomerPaymentType(getActiveCustomer(), paymentData);
           displayWelcome();
         })
       } else {
@@ -110,19 +106,34 @@ const mainMenuHandler = (err, { choice }) => {
       }
       break;
     }
-<<<<<<< HEAD
+    case 4: {
+      if (getActiveCustomer().id) {
+        promptAddCustomerProduct()
+          .then((productData) => {
+            addCustomerProduct(getActiveCustomer(), productData)
+              .then(lineNum => {
+                console.log(`\n${blue(productData.title + ' added to line ' + lineNum.id)}`)
+                displayWelcome();
+              });
+          });
+        break;
+      } else {
+        console.log(`\n${red('PLEASE SELECT A CUSTOMER (#2) THEN RETURN TO THIS COMMAND')}`);
+        displayWelcome();
+      }
+    }
 
     // View stale products
     case 7: {
-      if(isActiveCustomerSet()){
+      if (isActiveCustomerSet()) {
         getStaleProducts(getActiveCustomer().id).then(products => {
-          if(products.length > 0) {
+          if (products.length > 0) {
 
             // Required indent to conform with Joe's CLI code.
-            for(let product of products){
+            for (let product of products) {
               product = addSpace(product, ['product_id']);
             }
-            
+
             console.table(products);
           } else {
             console.log(' No stale products');
@@ -137,29 +148,6 @@ const mainMenuHandler = (err, { choice }) => {
       }
       break;
     }
-  }
-=======
-  
-
-
-  case 4: {
-      if(getActiveCustomer().id){
-        promptAddCustomerProduct()
-        .then((productData) => {
-          addCustomerProduct(getActiveCustomer(), productData)
-          .then(lineNum=>{
-            console.log(`\n${blue(productData.title + ' added to line ' + lineNum.id)}`)
-            displayWelcome();
-          });
-        });
-        break;
-      } else {
-        console.log(`\n${red('PLEASE SELECT A CUSTOMER (#2) THEN RETURN TO THIS COMMAND')}`);
-        displayWelcome();
-      }
-    }
->>>>>>> 1bfd0ed8fe173abc829652b740807bf33e543e3d
-
   }
 };
 

--- a/app/ui.js
+++ b/app/ui.js
@@ -8,6 +8,7 @@ const colors = require("colors/safe");
 const path = require('path');
 const { Database } = require('sqlite3').verbose();
 const db = new Database(path.join(__dirname, '..', 'bangazon.sqlite'));
+require('console.table');
 
 prompt.message = colors.blue("Bangazon Corp");
 
@@ -17,12 +18,14 @@ prompt.message = colors.blue("Bangazon Corp");
 const { promptNewCustomer } = require('./controllers/customerCtrl')
 const promptActivateCustomer = require('./controllers/activateCustomerCtrl')
 const { promptPaymentType } = require('./controllers/addPaymentTypeCtrl')
+const pressEnterToContinue = require('./controllers/pressEnterToContinue')
 
 /*
   MODELS
 */
 const getCustomers = require('./models/GetCustomers');
 const { addCustomerPaymentType } = require('./models/AddPaymentType');
+const getStaleProducts = require('./models/GetStaleProducts');
 
 /*
   ACTIVE CUSTOMER
@@ -83,6 +86,24 @@ const mainMenuHandler = (err, { choice }) => {
       }
       break;
     }
+
+    // View stale products
+    // 4 has stale products
+    case 7: {
+      //check if active customer
+      if(isActiveCustomerSet()){
+        getStaleProducts(getActiveCustomer().id).then(products => {
+          console.table(products);
+          pressEnterToContinue().then(() => {
+            displayWelcome();
+          });
+        });
+      } else {
+        console.log('Please choose active customer before checking their stale  products');
+        displayWelcome();
+      }
+      break;
+    }
   }
 
 };
@@ -102,7 +123,8 @@ const displayWelcome = () => {
   ${magenta('4.')} Add product to shopping cart
   ${magenta('5.')} Complete an order
   ${magenta('6.')} See product popularity
-  ${magenta('7.')} Leave Bangazon!`);
+  ${magenta('7.')} View stale products
+  ${magenta('.')} Leave Bangazon!`);
     prompt.get([{
       name: 'choice',
       description: 'Please make a selection'

--- a/data/orders.js
+++ b/data/orders.js
@@ -1,12 +1,12 @@
 module.exports.orders = [
   {
     customerId: 18,
-    orderDate: "2017-5-23",
+    orderDate: "2017-05-23",
     paymentTypeId: 1
   },
   {
     customerId: 3,
-    orderDate: "2017-7-28",
+    orderDate: "2017-07-28",
     paymentTypeId: null
   },
   {
@@ -16,87 +16,87 @@ module.exports.orders = [
   },
   {
     customerId: 10,
-    orderDate: "2018-3-9",
+    orderDate: "2018-03-09",
     paymentTypeId: null
   },
   {
     customerId: 1,
-    orderDate: "2017-9-22",
+    orderDate: "2017-09-22",
     paymentTypeId: 12
   },
   {
     customerId: 1,
-    orderDate: "2017-10-7",
+    orderDate: "2017-10-07",
     paymentTypeId: null
   },
   {
     customerId: 6,
-    orderDate: "2017-9-19",
+    orderDate: "2017-09-19",
     paymentTypeId: 5
   },
   {
     customerId: 12,
-    orderDate: "2017-5-23",
+    orderDate: "2017-05-23",
     paymentTypeId: 8
   },
   {
     customerId: 8,
-    orderDate: "2017-8-16",
+    orderDate: "2017-08-16",
     paymentTypeId: null
   },
   {
     customerId: 5,
-    orderDate: "2017-5-13",
+    orderDate: "2017-05-13",
     paymentTypeId: null
   },
   {
     customerId: 2,
-    orderDate: "2017-4-4",
+    orderDate: "2017-04-04",
     paymentTypeId: 10
   },
   {
     customerId: 9,
-    orderDate: "2017-7-14",
+    orderDate: "2017-07-14",
     paymentTypeId: 20
   },
   {
     customerId: 12,
-    orderDate: "2017-4-19",
+    orderDate: "2017-04-19",
     paymentTypeId: 15
   },
   {
     customerId: 8,
-    orderDate: "2018-2-12",
+    orderDate: "2018-02-12",
     paymentTypeId: null
   },
   {
     customerId: 1,
-    orderDate: "2018-2-14",
+    orderDate: "2018-02-14",
     paymentTypeId: 17
   },
   {
     customerId: 6,
-    orderDate: "2017-6-30",
+    orderDate: "2017-06-30",
     paymentTypeId: null
   },
   {
     customerId: 12,
-    orderDate: "2018-3-18",
+    orderDate: "2018-03-18",
     paymentTypeId: 15
   },
   {
     customerId: 9,
-    orderDate: "2018-3-5",
+    orderDate: "2018-03-05",
     paymentTypeId: 20
   },
   {
     customerId: 15,
-    orderDate: "2017-5-6",
+    orderDate: "2017-05-06",
     paymentTypeId: null
   },
   {
     customerId: 9,
-    orderDate: "2017-4-26",
+    orderDate: "2017-04-26",
     paymentTypeId: 20
   }
 ]

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "license": "ISC",
   "dependencies": {
     "chalk": "^1.1.3",
+    "console.table": "^0.10.0",
     "jsdoc": "^3.5.5",
     "prompt": "^1.0.0",
     "sqlite3": "^3.1.13"

--- a/test/getStaleProducts.test.js
+++ b/test/getStaleProducts.test.js
@@ -1,0 +1,11 @@
+'use strict'; 
+const getStaleProducts = require('../app/models/GetStaleProducts');
+const { assert: { equal, deepEqual, isArray } } = require('chai');
+
+describe('The stale products module', () => {
+    it('should return an array', () => {
+        getStaleProducts().then(products => {
+            isArray(products);
+        });
+    });
+});


### PR DESCRIPTION
# Description
Adds the ability for a customer to view their stale products -- products that are not selling well.  More information on how that is defined in Issue #9 .

Minor fixes to file names are also included.

## Related Ticket(s)
Finished Issue #9 (Customer can view stale products).

## Expected Behavior
After selecting a customer, and choosing to view stale products, you should see a table of stale product names and their ids.  

## Steps to Test Solution
1. Run `npm install`
1. Run `npm run db:reset`
1. Run `npm i -g`
1. Run `bangazon`
1. Select option `2` to select a customer.  (4 and 7 may have stale products)
1. Select option `7` to view stale products.
     1. A table should appear if there is a product.
          ```
          product_id  product_name
          ----------  ---------------------
            9         Handmade Granite Ball

           Press any key to continue
          ```
     1. `No stale products` should appear if there are none for that customer.
          ```
           No stale products
           Press any key to continue
          ```
1. Press enter to continue back to the main menu.

1. Run `npm test`
1. All test to do with stale products should pass.

## Testing
- [x] There are new unit tests in this PR, and I verify that there is full coverage of all new code.
- [ ] I certify that all existing tests pass

## Documentation
- [x] There is new documentation in this pull request that must be reviewed..
- [ ] I added documentation for any new classes/methods