### PR TITLE
remove duplicate addPayType

### DIFF
--- a/app/ui.js
+++ b/app/ui.js
@@ -34,7 +34,6 @@ const addPaymentType = require('./models/AddPaymentType');
 const { getProducts, updateProduct } = require('./models/UpdateProduct');
 const addCustomer = require('./models/AddCustomer');
 const addCustomerProduct = require('./models/AddCustomerProduct');
-const { addCustomerPaymentType } = require('./models/AddPaymentType');
 const getStaleProducts = require('./models/GetStaleProducts');
 
 /*
@@ -107,7 +106,6 @@ const mainMenuHandler = (err, { choice }) => {
         promptPaymentType().then((paymentData) => {
           addPaymentType(getActiveCustomer(),paymentData);
           console.log(`\n${blue(`${paymentData.payment} payment added`)}`)
-          addCustomerPaymentType(getActiveCustomer(), paymentData);
           displayWelcome();
         })
       } else {


### PR DESCRIPTION
# Description
Removes old addCustomerPaymentType function 

## Problem to Solve
Resolves console error for adding customer payment

## Expected Behavior
adding a payment works without console error

## Steps to Test Solution
Activate a customer, select _Create a payment option_, proceed through the prompts