### PR TITLE
Stale Product Tests

### DIFF
--- a/app/models/AddCustomerProduct.js
+++ b/app/models/AddCustomerProduct.js
@@ -10,7 +10,7 @@ const db = new sqlite.Database('./bangazon.sqlite');
  * @returns {Object.<{id: Number}>} lastID of product table (primary key of newly added row)
  */
 
-module.exports = ({ id }, { title, productTypeId, price, description, quantity}) => {
+module.exports = ({ id }, { title, productTypeId, price, description, quantity, date = null}) => {
     return new Promise((resolve, reject) => {
         db.run(`INSERT INTO products VALUES(
             null,
@@ -19,7 +19,7 @@ module.exports = ({ id }, { title, productTypeId, price, description, quantity})
             ${price},
             "${description}",
             ${id},
-            "${new Date().toISOString().split('T')[0]}",
+            "${date === null ? new Date().toISOString().split('T')[0] : date}",
             ${quantity}
         )`, function(err){
             if (err) return reject(err);

--- a/test/getStaleProducts.test.js
+++ b/test/getStaleProducts.test.js
@@ -18,7 +18,6 @@ describe('The stale products module', () => {
     price: 9.99,
   };
 
-
   const emptyTestArray = [];
 
   const fullTestArray = [

--- a/test/getStaleProducts.test.js
+++ b/test/getStaleProducts.test.js
@@ -1,11 +1,44 @@
-'use strict'; 
+'use strict';
 const getStaleProducts = require('../app/models/GetStaleProducts');
-const { assert: { equal, deepEqual, isArray } } = require('chai');
+const addProduct = require('../app/models/AddCustomerProduct');
+const { assert: { equal, deepEqual } } = require('chai');
 
 describe('The stale products module', () => {
-    it('should return an array', () => {
-        return getStaleProducts(4).then(products => {
-            isArray(products);
-        });
+  const testUser = {
+    id: 100,
+  };
+
+  const testProduct = {
+    id: testUser.id,
+    title: "A test product",
+    productTypeId: 1,
+    date: "2016-04-09",
+    description: "A  test product",
+    quantity: 1,
+    price: 9.99,
+  };
+
+
+  const emptyTestArray = [];
+
+  const fullTestArray = [
+    {
+      product_id: 51,
+      product_name: 'A test product'
+    }
+  ];
+
+  it('should deep equal an empty array when no product has been added', () => {
+    return getStaleProducts(testUser.id).then(products => {
+      deepEqual(products, emptyTestArray);
     });
+  });
+
+  it('should deep equal the example array when a product has been added', () => {
+    return addProduct(testProduct, testProduct).then(({ id }) => {
+      return getStaleProducts(testUser.id).then((products) => {
+        deepEqual(products, fullTestArray);
+      });
+    });
+  });
 });


### PR DESCRIPTION
# Description
Add deepEqual tests to stale products.  Also modify tests to insert data beforehand so the state of the database won't matter to pass the test.

## Related Ticket(s)
 Complete Issue #9 

## Proposed Changes
Insert data before test and then deep equal the output to make sure the feature is working properly.  Add date argument to createProduct.  If no date is given, it will default to the current date.

## Expected Behavior
"should deep equal an empty array when no product has been added" and  "should deep equal the example array when a product has been added" test should both pass.

## Steps to Test Solution

1. Run `node run db:reset`
1. Run `npm test`

## Testing

- [x] There are new unit tests in this PR, and I verify that there is full coverage of all new code.
- [ ] I certify that all existing tests pass